### PR TITLE
Suggested changes for #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ endif
 .PHONY: isclean
 .SILENT: isclean
 isclean:
-	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." && exit 1)
+	(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." && exit 1)
 
 # One big sed command instead of a function because OPERATOR_X vars 
 # are provided by shell, not make vars, and hard (imposisble?) to

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ CURRENT_COMMIT=$(shell git rev-parse --short=8 HEAD)
 CATALOG_VERSION?=$(CHANNEL)-$(BUILD_DATE)-$(CURRENT_COMMIT)
 
 ALLOW_DIRTY_CHECKOUT?=false
-SOURCE_DIR=operators
+SOURCE_DIR := operators
 
 # List of github.org repositories containing operators
 # This is in the format username/reponame
@@ -57,10 +57,6 @@ default: build
 
 .PHONY: clean
 clean:
-ifndef SOURCE_DIR
-	$(error SOURCE_DIR needs to be defined or you delete /)
-endif
-
 	# clean generated osd-operators manifests
 	rm -rf manifests/
 	# clean checked out operator source

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ALLOW_DIRTY_CHECKOUT?=false
 SOURCE_DIR := operators
 
 # List of github.org repositories containing operators
-# This is in the format username/reponame
+# This is in the format username/reponame separated by space:  user1/repo1 user2/repo2 user3/repo3
 OPERATORS := openshift/dedicated-admin-operator
 
 .PHONY: default

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,10 @@ default: build
 
 .PHONY: clean
 clean:
-	ifndef SOURCE_DIR
-	$(error SOURCE_DIR needs to be defined or you delete /)
+ifndef SOURCE_DIR
+		$(error SOURCE_DIR needs to be defined or you delete /)
+endif
+
 	# clean generated osd-operators manifests
 	rm -rf manifests/
 	# clean checked out operator source

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ default: build
 .PHONY: clean
 clean:
 ifndef SOURCE_DIR
-		$(error SOURCE_DIR needs to be defined or you delete /)
+	$(error SOURCE_DIR needs to be defined or you delete /)
 endif
 
 	# clean generated osd-operators manifests

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ operator-source:
 .PHONY: catalog
 catalog: operator-source
 	for DIR in $(SOURCE_DIR)/**/; do \
-		eval $$($(MAKE) ALLOW_DIRTY_CHECKOUT=$(ALLOW_DIRTY_CHECKOUT) -C $$DIR env --no-print-directory); \
+		eval $$($(MAKE) -C $$DIR env --no-print-directory); \
 		./scripts/gen_operator_csv.py $$DIR $$OPERATOR_NAME $$OPERATOR_NAMESPACE $$OPERATOR_VERSION $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$$OPERATOR_NAME:v$$OPERATOR_VERSION $(CHANNEL) || (echo "Failed to generate, cleaning up catalog-manifests/$$OPERATOR_NAME/$$OPERATOR_VERSION" && rm -rf catalog-manifests/$$OPERATOR_NAME/$$OPERATOR_VERSION && exit 3); \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ manifests/00-catalog.yaml:
 manifests/operators: operator-source
 	mkdir -p manifests/ ;\
 	for DIR in $(SOURCE_DIR)/**/ ; do \
-		eval $$($(MAKE) ALLOW_DIRTY_CHECKOUT=$(ALLOW_DIRTY_CHECKOUT) -C $$DIR env --no-print-directory); \
+		eval $$($(MAKE) -C $$DIR env --no-print-directory); \
 		TEMPLATE=scripts/templates/operator.yaml; \
 		DEST=manifests/10-$${OPERATOR_NAME}.yaml; \
 		$(SED_CMD) $$TEMPLATE > $$DEST; \

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following variables (with defaults) are available for overriding by the user
 - IMAGE_REPOSITORY - target container repository ($USER)
 - IMAGE_NAME - target image name ($OPERATOR_NAME)
 - ALLOW_DIRTY_CHECKOUT - if a dirty local checkout is allowed (false)
+- SKIP_GITREFRESH - if set, skip performing `git reset` and `git pull` on all operator source trees (false)
 
 Note that `IMAGE_REPOSITORY` defaults to the current user's name.  The default behavior of `make build` and `make push` will therefore be to create images in the user's namespace.  Automation would override this to push to an organization like this:
 

--- a/checkout-operator.mk
+++ b/checkout-operator.mk
@@ -3,7 +3,9 @@
 #  2 - github repo name (operator name)
 define checkout_operator
 	mkdir -p $(SOURCE_DIR); \
-	pushd $(SOURCE_DIR); \
-	git clone -b master https://github.com/$(1)/$(2).git || (pushd $(2) && git pull && popd); \
-	popd
+	if [[ ! -d $(SOURCE_DIR)/$(2) ]]; then \
+		git clone -b master https://github.com/$(1)/$(2).git $(SOURCE_DIR)/$(2) ;\
+	else \
+		cd $(SOURCE_DIR)/$(2) git reset --hard && git pull --force && cd ../.. ;\
+	fi
 endef

--- a/checkout-operator.mk
+++ b/checkout-operator.mk
@@ -6,6 +6,10 @@ define checkout_operator
 	if [[ ! -d $(SOURCE_DIR)/$(2) ]]; then \
 		git clone -b master https://github.com/$(1)/$(2).git $(SOURCE_DIR)/$(2) ;\
 	else \
-		cd $(SOURCE_DIR)/$(2) git reset --hard && git pull --force && cd ../.. ;\
+		if [[  -z "$${SKIP_GITREFRESH}" ]]; then \
+			cd $(SOURCE_DIR)/$(2) git reset --hard && git pull --force && cd ../.. ;\
+		else \
+			echo "SKIP_GITREFRESH set, skipping git refresh for $(1)$(2)" ;\
+		fi ;\
 	fi
 endef

--- a/checkout-operator.mk
+++ b/checkout-operator.mk
@@ -9,7 +9,7 @@ define checkout_operator
 		if [[  -z "$${SKIP_GITREFRESH}" ]]; then \
 			cd $(SOURCE_DIR)/$(2) git reset --hard && git pull --force && cd ../.. ;\
 		else \
-			echo "SKIP_GITREFRESH set, skipping git refresh for $(1)$(2)" ;\
+			echo "SKIP_GITREFRESH set, skipping git refresh for $(1)/$(2)" ;\
 		fi ;\
 	fi
 endef

--- a/scripts/gen_operator_csv.py
+++ b/scripts/gen_operator_csv.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     print("Generating CSV for version: %s" % operator_version)
 
     with open('scripts/templates/csv.yaml', 'r') as stream:
-        csv = yaml.load(stream, Loader=yaml.FullLoader)
+        csv = yaml.load(stream, Loader=yaml.BaseLoader)
 
     # set templated values
     csv['metadata']['name'] = operator_name

--- a/scripts/gen_operator_csv.py
+++ b/scripts/gen_operator_csv.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     print("Generating CSV for version: %s" % operator_version)
 
     with open('scripts/templates/csv.yaml', 'r') as stream:
-        csv = yaml.load(stream, Loader=yaml.BaseLoader)
+        csv = yaml.load(stream)
 
     # set templated values
     csv['metadata']['name'] = operator_name


### PR DESCRIPTION
Summary of changes for #2:

Makefile:

* Move list of operators into a Makefile variable `$OPERATORS`
* Silence `isclean` output
* Explictly pass `ALLOW_DIRTY_CECKOUT` to "child" `make` calls (eg `make env`)
* Resolve make bash error in `manifests/operators` target
* Use Makefile variable `$OPERATORS` to loop over and fetch source
* Git source fetcher is a little more friendly:
  * Checks to see if the directory exists and git pulls, otherwise clones
  * Resolves minor errors when the directory does exist

scripts/gen_operator_csv.py:

* Fix YAML loading error by changing Loader to use `yaml.BaseLoader` instead of `yaml.FullLoader`

Signed-off-by: Lisa Seelye <lseelye@redhat.com>