### PR TITLE
Add alertmanager operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,10 @@ GIT_TAG=release-$(CATALOG_VERSION)
 ALLOW_DIRTY_CHECKOUT?=false
 SOURCE_DIR := operators
 
+MANIFESTDIR := ./manifests
 # List of github.org repositories containing operators
 # This is in the format username/reponame separated by space:  user1/repo1 user2/repo2 user3/repo3
-OPERATORS := openshift/dedicated-admin-operator
+OPERATORS := openshift/dedicated-admin-operator dak1n1/configure-alertmanager-operator
 
 .PHONY: default
 default: build
@@ -60,31 +61,30 @@ clean:
 isclean:
 	(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." && exit 1)
 
+.PHONY: manifestdir
+.SILENT: manifestdir
+manifestdir:
+	mkdir -p $(MANIFESTDIR)
+
+# create CatalogSource yaml
 .PHONY: manifests/catalog
-manifests/catalog: catalog
-	mkdir -p manifests/
-	# create CatalogSource yaml
-	TEMPLATE=scripts/templates/catalog.yaml; \
-	DEST=manifests/00-catalog.yaml; \
-	$(call process_template,.,$$TEMPLATE,$$DEST)
+manifests/catalog: manifestdir catalog
+	@$(call process_template,.,scripts/templates/catalog.yaml,manifests/00-catalog.yaml)
 
 # create yaml per operator
 .PHONY: manifests/operators
-manifests/operators: catalog
-	mkdir -p manifests/ ;\
-	for DIR in $(SOURCE_DIR)/**/ ; do \
-		SOURCE_NAME=$$(echo $$DIR | cut -d/ -f2); \
-		TEMPLATE=scripts/templates/operator.yaml; \
-		DEST=manifests/10-$${SOURCE_NAME}.yaml; \
-		$(call process_template,$$DIR,$$TEMPLATE,$$DEST); \
+manifests/operators: manifestdir catalog
+	@for operatorrepo in $(OPERATORS) ; do \
+		reponame="$$(echo $$operatorrepo | cut -d / -f 2-)" ; \
+		$(call process_template,$(SOURCE_DIR)/$$reponame,scripts/templates/operator.yaml,manifests/10-$${reponame}.yaml); \
 	done
 
 .PHONY: manifests
-manifests: manifests/catalog manifests/operators
+manifests: manifestdir manifests/catalog manifests/operators 
 
 .PHONY: operator-source
 operator-source:
-	for operator in $(OPERATORS); do \
+	@for operator in $(OPERATORS); do \
 		org="$$(echo $$operator | cut -d / -f 1)" ; \
 		reponame="$$(echo $$operator | cut -d / -f 2-)" ; \
 		echo "org = $$org reponame = $$reponame" ; \
@@ -93,17 +93,50 @@ operator-source:
 	done
 
 .PHONY: catalog
-catalog: operator-source
-	for DIR in $(SOURCE_DIR)/**/; do \
-		eval $$($(MAKE) -C $$DIR env --no-print-directory); \
-		./scripts/gen_operator_csv.py $$DIR $$OPERATOR_NAME $$OPERATOR_NAMESPACE $$OPERATOR_VERSION $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$$OPERATOR_NAME:v$$OPERATOR_VERSION $(CHANNEL) || (echo "Failed to generate, cleaning up catalog-manifests/$$OPERATOR_NAME/$$OPERATOR_VERSION" && rm -rf catalog-manifests/$$OPERATOR_NAME/$$OPERATOR_VERSION && exit 3); \
+catalog: manifestdir operator-source
+	@unset OPERATOR_NAME OPERATOR_VERSION OPERATOR_NAMESPACE OPERATOR_IMAGE_URI ;\
+	for operatorrepo in $(OPERATORS); do \
+		operator="$$(echo $$operatorrepo | cut -d / -f2)" ;\
+		echo "Building catalog for $$operator in $(SOURCE_DIR)/$$operator" ;\
+		eval $$($(MAKE) -C $(SOURCE_DIR)/$$operator env --no-print-directory); \
+		if [[ -z "$${OPERATOR_NAME}" || -z "$${OPERATOR_NAMESPACE}" || -z "$${OPERATOR_VERSION}" ]]; then \
+			echo "Couldn't determine OPERATOR_NAME, OPERATOR_NAMESPACE or OPERATOR_VERSION from $(SOURCE_DIR)/$$operator. make env output follows" ; \
+			$(MAKE) -C $(SOURCE_DIR)/$$operator env ; \
+			unset OPERATOR_NAME OPERATOR_VERSION OPERATOR_NAMESPACE OPERATOR_IMAGE_URI ;\
+			exit 3 ;\
+		else \
+			./scripts/gen_operator_csv.py $(SOURCE_DIR)/$$operator $$OPERATOR_NAME $$OPERATOR_NAMESPACE $$OPERATOR_VERSION $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$$OPERATOR_NAME:v$$OPERATOR_VERSION $(CHANNEL) 1>/dev/null ;\
+			if [[ $$? -ne 0 ]]; then \
+				echo "Failed to generate, cleaning up catalog-manifests/$$OPERATOR_NAME/$$OPERATOR_VERSION" ;\
+				rm -rf catalog-manifests/$$OPERATOR_NAME/$$OPERATOR_VERSION ;\
+				unset OPERATOR_NAME OPERATOR_VERSION OPERATOR_NAMESPACE OPERATOR_IMAGE_URI ;\
+				exit 3; \
+			fi ;\
+			unset OPERATOR_NAME OPERATOR_VERSION OPERATOR_NAMESPACE OPERATOR_IMAGE_URI ;\
+		fi ; \
 	done
 
 .PHONY: check-operator-images
 check-operator-images: operator-source
-	for DIR in $(SOURCE_DIR)/**/; do \
-		eval $$($(MAKE) -C $$DIR env --no-print-directory); \
-		docker pull $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$$OPERATOR_NAME:v$$OPERATOR_VERSION || (echo "Image cannot be pulled: $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$$OPERATOR_NAME:v$$OPERATOR_VERSION" && exit 1); \
+	@unset OPERATOR_NAME OPERATOR_VERSION OPERATOR_NAMESPACE OPERATOR_IMAGE_URI ;\
+	for operator in $(OPERATORS); do \
+		org="$$(echo $$operator | cut -d / -f 1)" ; \
+		reponame="$$(echo $$operator | cut -d / -f 2-)" ; \
+		eval $$($(MAKE) -C $(SOURCE_DIR)/$$reponame env --no-print-directory); \
+		if [[ -z "$${OPERATOR_NAME}" || -z "$${OPERATOR_NAMESPACE}" || -z "$${OPERATOR_VERSION}" ]]; then \
+			echo "Couldn't determine OPERATOR_NAME, OPERATOR_NAMESPACE or OPERATOR_VERSION from $(SOURCE_DIR)/$$operator. make env output follows" ; \
+			$(MAKE) -C $(SOURCE_DIR)/$$operator env ; \
+			unset OPERATOR_NAME OPERATOR_VERSION OPERATOR_NAMESPACE OPERATOR_IMAGE_URI ;\
+			exit 3 ;\
+		else \
+			docker pull $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$$OPERATOR_NAME:v$$OPERATOR_VERSION ;\
+			if [[ $$? -ne 0 ]]; then \
+				echo "Image cannot be pulled: $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$$OPERATOR_NAME:v$$OPERATOR_VERSION" ;\
+				unset OPERATOR_NAME OPERATOR_VERSION OPERATOR_NAMESPACE OPERATOR_IMAGE_URI  ;\
+				exit 1 ; \
+			fi ;\
+			unset OPERATOR_NAME OPERATOR_VERSION OPERATOR_NAMESPACE OPERATOR_IMAGE_URI ;\
+		fi ;\
 	done
 
 .PHONY: build
@@ -136,3 +169,8 @@ git-push: git-tag
 .PHONY: version
 version:
 	@echo $(CATALOG_VERSION)
+
+.PHONY: env
+.SILENT: env
+env:
+	echo


### PR DESCRIPTION
This PR makes the following changes:

# scripts/gen_operator_csv.py (8fd92c1c88adc2cae821422e2c669554f658641e)

* Fix typo, add guardrails around missing assets
* If the `manifests` directory is missing, complain and quit. If there are no `Deployments` detected, complain and quit.

# Makefile (4d99ecdc6fa2fc7b642363e4a9dddfdc04fc8e8e)

* In all places substitute filesystem glob matching in `$(SOURCE_DIR)/**/` to iterate over `$(OPERATORS)` and determine the name of the repository from the list.
* Adds guardrails around certain variables that become part of the running environment due to `eval $(make -C operatordir) env`:
  * Tests are made to ensure the variables the make target cares about are found
  * Unsets variables so that subsequent loop iterations (and other make targets) aren't polluted with previous values
* Makes more explicit the testing around failures: Instead of `|| (... && exit)`, check the previous command's exit value in an `if-then-else`-style control block.
* Created an `env` target, which echos nothing, so that `functions.mk`'s `/process_template` doesn't emit an error.
* Most targets are now silent; they do not print the Bash that make is running. (To be more verbose try `make SHELL="bash -x"`)
* Consolidated multiple `mkdir -p manifests` into its own make target, `manifestdir`, with accompanying variable `MANIFESTDIR`